### PR TITLE
Dialog cleanup

### DIFF
--- a/src/css/common/_!common.scss
+++ b/src/css/common/_!common.scss
@@ -2,5 +2,6 @@
 @import "lucide";
 @import "modal";
 @import "prompt";
+@import "confirm";
 
 @import "error-handler";

--- a/src/css/common/_confirm.scss
+++ b/src/css/common/_confirm.scss
@@ -1,21 +1,10 @@
-/* Prompt Dialog Styles */
+/* Confirm Dialog Styles */
 
-.prompt {
+.confirm {
     display: flex;
     flex-direction: column;
     gap: 1rem;
     padding: 0.5rem;
-
-    &__input {
-        font: inherit;
-        padding: 0.4rem 0.5rem;
-        background: var(--color-section-darken-5);
-        border: 1px solid var(--color-section-lighten-5);
-        border-radius: 3px;
-        color: var(--color-text);
-        width: 100%;
-        box-sizing: border-box;
-    }
 
     &__buttons {
         display: flex;
@@ -33,5 +22,13 @@
         cursor: pointer;
 
         &:hover { background: var(--color-section-lighten-5); }
+
+        &.confirm__danger {
+            background: #883333;
+            color: #fff;
+            border-color: transparent;
+
+            &:hover { background: #aa3a3a; }
+        }
     }
 }

--- a/src/css/common/_modal.scss
+++ b/src/css/common/_modal.scss
@@ -15,14 +15,19 @@ div#modal-container {
         position: absolute !important;
         pointer-events: auto;
         border-radius: 6px;
-        min-width: max-content;
-        max-width: fit-content;
+        min-width: 0;
+        max-width: calc(100vw - 1rem);
+        max-height: calc(100vh - 2rem);
+        box-sizing: border-box;
         box-shadow: 0 5px 15px -5px black;
         outline: 0;
 
+        background-color: var(--color-foreground);
         background-image: url("/packs/media/src/styles/images/extras/hex-6029a8f11b7ec7b1f0638e3d8f18b6cb.png");
         background-position: left 2rem;
         background-repeat: repeat-x;
+        color: var(--color-text);
+        border: 1px solid var(--color-section);
 
         &.modal-fixed {
             position: fixed !important;
@@ -35,10 +40,10 @@ div#modal-container {
         div.ui-dialog-titlebar {
             position: relative;
             padding: 0;
-            border: unset !important;
+            border: 0;
             border-radius: 6px 6px 0 0;
-            color: inherit !important;
             background-color: #00000066;
+            color: var(--color-text);
             cursor: grab;
             height: 2rem;
 
@@ -53,29 +58,20 @@ div#modal-container {
 
             button.ui-dialog-titlebar-close {
                 position: absolute;
-                height: 100%;
                 margin: 0;
                 right: 0;
                 top: 0;
                 padding: 0;
-                width: 3em;
+                width: 2rem;
+                height: 2rem;
                 outline: 0;
                 border: 0;
-                border-left: 1px solid #66666666;
-
-                border-width: 0 0 0 1px !important;
-                background: unset;
+                background: transparent;
+                color: var(--color-text);
                 box-shadow: unset;
 
                 &:hover,
-                &:active {
-                    background: #ffffff10;
-
-                    span.ui-icon {
-                        background-image: url(/packs/media/images/ui-icons_ffffff_256x240-bf27228a.png);
-                        background-position: -96px -128px;
-                    }
-                }
+                &:active { background: #ffffff10; }
             }
         }
 
@@ -88,7 +84,7 @@ div#modal-container {
         div.ui-dialog-content {
             position: relative;
             padding: 1em 1em;
-            min-width: fit-content;
+            min-width: 0;
 
             height: 90% !important;
             overflow: hidden scroll;
@@ -100,7 +96,7 @@ div#modal-container {
             background-color: unset !important;
             color: unset !important;
             
-            width: inherit !important;
+            width: 100% !important;
             box-sizing: border-box;
 
             .ui-tabs {

--- a/src/css/components/_TemplateBuilder.scss
+++ b/src/css/components/_TemplateBuilder.scss
@@ -84,7 +84,6 @@
         padding: 0 0.5rem;
         opacity: 0.7;
         font-style: italic;
-        flex: 1;
         line-height: 1;
     }
 

--- a/src/css/components/_TemplateBuilder.scss
+++ b/src/css/components/_TemplateBuilder.scss
@@ -179,21 +179,3 @@
     }
 }
 
-.template-builder-toast {
-    position: fixed;
-    bottom: 1.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 9999;
-    padding: 0.6rem 1rem;
-    background: var(--color-foreground);
-    color: var(--color-text);
-    border: 1px solid var(--color-section-lighten-5);
-    border-radius: 3px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-
-    &--show { opacity: 1; }
-}

--- a/src/css/components/_TemplateBuilder.scss
+++ b/src/css/components/_TemplateBuilder.scss
@@ -1,38 +1,3 @@
-/* The dialog wrapper. Targeted via `dialogClass` on jQuery UI. */
-.template-builder-dialog {
-    &.ui-dialog {
-        border: 1px solid var(--color-section);
-        /* Override modal.scss's `min-width: max-content` so we can shrink below content width. */
-        min-width: 0 !important;
-        max-width: calc(100vw - 1rem) !important;
-        max-height: calc(100vh - 2rem);
-        box-sizing: border-box;
-    }
-
-    &.ui-dialog,
-    .ui-dialog-content,
-    .ui-dialog-titlebar {
-        background: var(--color-foreground);
-        color: var(--color-text);
-    }
-
-    .ui-dialog-titlebar { border: 0; }
-
-    /* Modal.scss sets `min-width: fit-content` on the content area; override so it can shrink. */
-    .ui-dialog-content {
-        min-width: 0 !important;
-    }
-
-    .ui-dialog-titlebar-close {
-        background: transparent;
-        border: 0;
-        color: var(--color-text);
-        font-size: 1.25rem;
-        width: 2rem;
-        height: 2rem;
-    }
-}
-
 .template-builder-row {
     display: flex;
     flex-wrap: wrap;
@@ -211,48 +176,6 @@
         white-space: nowrap;
 
         &:hover { background: var(--color-section-lighten-5); }
-    }
-}
-
-.template-builder-confirm {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 0.5rem;
-
-    &__buttons {
-        display: flex;
-        gap: 0.5rem;
-        justify-content: flex-end;
-    }
-
-    button {
-        padding: 0.4rem 0.85rem;
-        font: inherit;
-        border-radius: 3px;
-        border: 1px solid var(--color-section-lighten-5);
-        background: var(--color-section);
-        color: var(--color-text);
-        cursor: pointer;
-
-        &:hover { background: var(--color-section-lighten-5); }
-
-        &.template-builder-confirm__danger {
-            background: #883333;
-            color: #fff;
-            border-color: transparent;
-
-            &:hover { background: #aa3a3a; }
-        }
-    }
-
-    textarea {
-        font: inherit;
-        padding: 0.4rem 0.5rem;
-        background: var(--color-section-darken-5);
-        border: 1px solid var(--color-section-lighten-5);
-        border-radius: 3px;
-        color: var(--color-text);
     }
 }
 

--- a/src/js/components/TicketReasons.ts
+++ b/src/js/components/TicketReasons.ts
@@ -70,6 +70,7 @@ export default class TicketReasons extends Component {
 		this.builder = new TemplateBuilder({
 			targetField: target,
 			label: "Ticket reply templates",
+			insertMode: "replace",
 			defaults: TicketReasons.defaultTemplates,
 			getTemplates: () => this.Settings.buttons.map((b) => ({
 				title: b.title ?? b.name ?? "",

--- a/src/js/components/TicketReasons.ts
+++ b/src/js/components/TicketReasons.ts
@@ -76,8 +76,13 @@ export default class TicketReasons extends Component {
 				body: b.body ?? b.text ?? "",
 			})),
 			setTemplates: (next) => { this.Settings.buttons = next; },
-			transform: (template) => `${this.Settings.greeting}${template.body}`
-				.replace(/%reporterName%/g, this.reporterName),
+			transform: (template) => {
+				const greeting = this.Settings.greeting;
+				const text = greeting.includes("%body%")
+					? greeting.replace("%body%", template.body)
+					: `${greeting}${template.body}`;
+				return text.replace(/%reporterName%/g, this.reporterName);
+			},
 			pinnedChip: {
 				title: "Greeting",
 				getBody: () => this.Settings.greeting,

--- a/src/js/models/api/Danbooru.ts
+++ b/src/js/models/api/Danbooru.ts
@@ -6,18 +6,12 @@ export default class Danbooru {
 
     private static _cachedModules: any;
     private static get Modules(): any {
-        if (!this._cachedModules) {
-            this._cachedModules = XM.Window["Danbooru"];
-            if (!this._cachedModules) this._cachedModules = {};
-        }
+        if (!this._cachedModules) this._cachedModules = XM.Window["Danbooru"];
         return this._cachedModules;
     }
 
-    private static _cachedModuleCount: number;
     private static get hasModules(): boolean {
-        if (typeof this._cachedModuleCount == "undefined")
-            this._cachedModuleCount = Object.keys(this.Modules).length;
-        return this._cachedModuleCount > 0;
+        return !!this.Modules && Object.keys(this.Modules).length > 0;
     }
 
     public static Autocomplete = {
@@ -31,25 +25,21 @@ export default class Danbooru {
         apply(): void {
             if (!Danbooru.hasModules) return;
             Danbooru.Modules.Blacklist.apply();
-
         },
 
         initialize_anonymous_blacklist(): void {
             if (!Danbooru.hasModules) return;
             Danbooru.Modules.Blacklist.initialize_anonymous_blacklist();
-
         },
 
         initialize_all(): void {
             if (!Danbooru.hasModules) return;
             Danbooru.Modules.Blacklist.initialize_all();
-
         },
 
         initialize_disable_all_blacklists(): void {
             if (!Danbooru.hasModules) return;
             Danbooru.Modules.Blacklist.initialize_disable_all_blacklists();
-
         },
 
         stub_vanilla_functions(): void {
@@ -70,174 +60,16 @@ export default class Danbooru {
         },
     }
 
-    public static Dialog = (!Danbooru.hasModules) ? Danbooru.Modules.Dialog : undefined/*  class {
-        static get container(): JQuery<HTMLDivElement> {
-            if (!Danbooru.hasModules) return;
-            return Danbooru.Modules.Dialog.container;
-        }
-        constructor(element, params = {}): any {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Dialog.process_formatting = fn;
-        },
-    } */;
+    public static get DTextFormatter() { return this.Modules?.DTextFormatter; }
 
-    // public static DText = {
-    //     get buttons(): DTextButton[] {
-    //         if (!Danbooru.hasModules) return;
-    //         return Danbooru.Modules.DText.buttons;
-    //     },
-    //     set buttons(values: DTextButton[]) {
-    //         if (!Danbooru.hasModules) return;
-    //         Danbooru.Modules.DText.buttons = values;
-    //     },
-    //     override_formatting(fn: (content: string, input: JQuery<HTMLInputElement>) => void): void {
-    //         if (!Danbooru.hasModules) return;
-    //         Danbooru.Modules.DText.process_formatting = fn;
-    //     },
-    //     initialize_input($element: JQuery<HTMLDivElement>): void {
-    //         if (!Danbooru.hasModules) return;
-    //         (Danbooru.Modules.DText.initialize_input || Danbooru.Modules.DText.initialze_input)($element);
-    //     },
-	// 	/** Add formatters to all appropriate inputs */
-	// 	initialize_all_inputs() {
-	// 		if (!Danbooru.hasModules) return;
-    //         Danbooru.Modules.DText.initialize_all_inputs();
-	// 	},
-    // };
-
-    // public static DTextFormatter = Danbooru.hasModules ? Danbooru.Modules.DTextFormatter : undefined;
-    public static get DTextFormatter() { return XM.Window["Danbooru"]?.DTextFormatter; }
-
-    public static Post = {
-        vote(post_id: number, scoreDifference: number, preventUnvote?: boolean): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.vote(post_id, scoreDifference, preventUnvote);
-        },
-        initialize_all(): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.initialize_all();
-        },
-        update(post_id: number, params: any): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.update(post_id, params);
-        },
-        delete_with_reason(post_id: number, reason: string, reload_after_delete: boolean): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.delete_with_reason(post_id, reason, reload_after_delete);
-        },
-        undelete(post_id: number): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.undelete(post_id);
-        },
-        approve(post_id: number, should_reload = false): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.approve(post_id, should_reload);
-        },
-        disapprove(post_id: number, reason: string, should_reload = false): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.disapprove(post_id, reason, should_reload);
-        },
-        unapprove(post_id: number): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.unapprove(post_id);
-        },
-        resize_cycle_mode(): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.resize_cycle_mode();
-        },
-        resize_to(size: string): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.resize_to(size);
-        },
-        resize_to_internal(size: string): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.resize_to_internal(size);
-        },
-        resize_notes(): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Post.resize_notes();
-        }
-    };
-
-    public static PostModeMenu = {
-        change(): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.PostModeMenu.change();
-        },
-        click(e: Event | any): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.PostModeMenu.click(e);
-        },
-        change_tag_script(script: number): void {
-            if (!Danbooru.hasModules) return;
-            const event = new CustomEvent("remt.dummy-event");
-            event["key"] = script;
-            Danbooru.Modules.PostModeMenu.change_tag_script(event);
-        },
-    };
-
-    public static Note = {
-        Box: {
-            scale_all(): void {
-                if (!Danbooru.hasModules) return;
-                Danbooru.Modules.Note.Box.scale_all();
-
-            }
-        },
-
-        TranslationMode: {
-            active(state?: boolean): Promise<boolean> {
-                if (!Danbooru.hasModules) return;
-                if (state !== undefined) Danbooru.Modules.Note.TranslationMode.active = state;
-                return Promise.resolve(Danbooru.Modules.Note.TranslationMode.active);
-
-            },
-
-            toggle(): void {
-                if (!Danbooru.hasModules) return;
-                Danbooru.Modules.Note.TranslationMode.toggle(new CustomEvent("remt.dummy-event"));
-
-            },
-        }
-    };
-
-    public static Thumbnails = {
-
-        initialize(): void {
-            if (!Danbooru.hasModules) return;
-            Danbooru.Modules.Thumbnails.initialize();
-        }
-
-    }
-
-    public static Shortcuts = {
-
-        set disabled(value: boolean) {
-            Danbooru.Modules.Shortcuts.disabled = value;
-        }
-
-    }
-
-    public static E621 = {
-
-        addDeferredPosts(posts: []): void {
-            XM.Window["___deferred_posts"] = XM.Window["___deferred_posts"] || {}
-            XM.Window["___deferred_posts"] = $.extend(XM.Window["___deferred_posts"], posts);
-        }
-
-    }
+    /** The page-side jQuery instance. Required when interacting with page-side jQuery state (e.g. `.data()`), since the userscript runs in a sandbox with its own jQuery. */
+    public static get jQuery(): typeof $ | undefined { return XM.Window["jQuery"]; }
 
     public static notice(input: string, permanent?: boolean): void {
-        Danbooru.Modules.notice(input, permanent);
+        this.Modules?.notice(input, permanent);
     }
 
     public static error(input: string): void {
-        Danbooru.Modules.error(input);
+        this.Modules?.error(input);
     }
-}
-
-export type DTextButton = {
-    icon: string;
-    title: string;
-    content: string;
 }

--- a/src/js/models/structure/Confirm.ts
+++ b/src/js/models/structure/Confirm.ts
@@ -1,0 +1,65 @@
+import Modal from "./Modal";
+
+export interface ConfirmOptions {
+	title?: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	/** Styles the confirm button as a destructive action. */
+	danger?: boolean;
+}
+
+/**
+ * A yes/no dialog. Resolves true on confirm, false on cancel or close.
+ */
+export class Confirm extends Modal {
+
+	private _promise: Promise<boolean>;
+	public get promise(): Promise<boolean> { return this._promise; }
+
+	constructor(message: string, opts: ConfirmOptions = {}) {
+		super({
+			title: opts.title ?? "Confirm",
+			autoOpen: true,
+			width: "auto",
+			minHeight: 50,
+		});
+
+		const $body = Confirm.buildBody(message, opts);
+		this.addContent($body);
+
+		this._promise = new Promise((resolve) => {
+			let closed = false;
+			const done = (value: boolean) => {
+				if (closed) return;
+				closed = true;
+				this.destroy();
+				resolve(value);
+			};
+			$body.find("[data-confirm-action='cancel']").on("click", () => done(false));
+			$body.find("[data-confirm-action='confirm']").on("click", () => done(true));
+			this.getElement().on("dialogclose", () => done(false));
+		});
+	}
+
+	private static buildBody(message: string, opts: ConfirmOptions): JQuery<HTMLElement> {
+		const $root = $("<div>").addClass("confirm");
+		$("<div>").addClass("confirm__message").text(message).appendTo($root);
+
+		const $buttons = $("<div>").addClass("confirm__buttons").appendTo($root);
+		$("<button>")
+			.attr({ type: "button", "data-confirm-action": "cancel" })
+			.text(opts.cancelLabel ?? "Cancel")
+			.appendTo($buttons);
+		const $confirm = $("<button>")
+			.attr({ type: "button", "data-confirm-action": "confirm" })
+			.text(opts.confirmLabel ?? "OK");
+		if (opts.danger) $confirm.addClass("confirm__danger");
+		$confirm.appendTo($buttons);
+
+		return $root;
+	}
+
+	public static ask(message: string, opts?: ConfirmOptions): Promise<boolean> {
+		return new Confirm(message, opts).promise;
+	}
+}

--- a/src/js/models/structure/Modal.ts
+++ b/src/js/models/structure/Modal.ts
@@ -1,4 +1,5 @@
 import Util from "../../utilities/Util";
+import { makeIcon } from "../../utilities/UtilIcons";
 import PreparedStructure from "./PreparedStructure";
 
 export default class Modal {
@@ -39,6 +40,7 @@ export default class Modal {
             .dialog({
                 autoOpen: config.autoOpen,
                 appendTo: "#modal-container",
+                dialogClass: config.dialogClass,
 
                 resizable: false,
 
@@ -66,6 +68,9 @@ export default class Modal {
 
         const ui = this.$modal.closest('.ui-dialog');
         ui.draggable('option', 'containment', '#modal-container');
+
+        const closeBtn = ui.find(".ui-dialog-titlebar-close")[0];
+        if (closeBtn) closeBtn.replaceChildren(makeIcon("close"));
 
         // Replace the modal structure on window open, if necessary
         if (config.structure)
@@ -118,6 +123,7 @@ export default class Modal {
         result.maxHeight = typeof config.minHeight === "undefined" ? undefined : config.maxHeight;
 
         result.disabled = typeof config.disabled === "undefined" ? false : config.disabled;
+        result.dialogClass = typeof config.dialogClass === "undefined" ? "" : config.dialogClass;
         if (typeof config.position === "undefined") result.position = { my: "center", at: "center" };
         else
             result.position = {
@@ -244,6 +250,8 @@ export interface ModalConfig {
 
     /** If true, triggers are disabled */
     disabled?: boolean;
+    /** Extra CSS class added to the `.ui-dialog` wrapper. */
+    dialogClass?: string;
     /** Initial position of the modal window */
     position?: {
         at: string;

--- a/src/js/models/structure/Prompt.ts
+++ b/src/js/models/structure/Prompt.ts
@@ -1,50 +1,75 @@
 import Modal from "./Modal";
 
+export interface PromptOptions {
+	title?: string;
+	placeholder?: string;
+	defaultValue?: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+}
+
 /**
- * Creates a draggable window asking for user input
+ * A single-line text input dialog. Resolves the entered string on submit, null on cancel or close.
  */
 export class Prompt extends Modal {
 
-    private promise: Promise<string | number | string[]>;
+	private _promise: Promise<string | null>;
+	public get promise(): Promise<string | null> { return this._promise; }
 
-    private $form: JQuery<HTMLElement>;
-    private $input: JQuery<HTMLElement>;
+	constructor(message: string, opts: PromptOptions = {}) {
+		super({
+			title: opts.title ?? "Prompt",
+			autoOpen: true,
+			width: "auto",
+			minHeight: 50,
+		});
 
-    constructor(title = "Prompt") {
-        super({
-            title: title,
-            minHeight: 50,
-        });
+		const $body = Prompt.buildBody(message, opts);
+		this.addContent($body);
 
-        this.createForm();
-        this.addContent(this.$form);
-        this.open();
-        this.$input.trigger("focus");
+		const $input = $body.find<HTMLInputElement>(".prompt__input");
+		$input.trigger("focus");
 
-        this.promise = new Promise((resolve) => {
-            this.$form.on("submit", (event) => {
-                event.preventDefault();
-                this.destroy();
-                resolve(this.$input.val());
-            });
-        });
-    }
+		this._promise = new Promise((resolve) => {
+			let closed = false;
+			const done = (value: string | null) => {
+				if (closed) return;
+				closed = true;
+				this.destroy();
+				resolve(value);
+			};
+			$body.find("[data-prompt-action='cancel']").on("click", () => done(null));
+			$body.on("submit", (event) => {
+				event.preventDefault();
+				done($input.val() as string);
+			});
+			this.getElement().on("dialogclose", () => done(null));
+		});
+	}
 
-    private createForm(): void {
-        this.$form = $("<form>")
-            .addClass("prompt-input");
+	private static buildBody(message: string, opts: PromptOptions): JQuery<HTMLElement> {
+		const $root = $("<form>").addClass("prompt");
+		$("<div>").addClass("prompt__message").text(message).appendTo($root);
+		$("<input>")
+			.addClass("prompt__input")
+			.attr({ type: "text", placeholder: opts.placeholder ?? "" })
+			.val(opts.defaultValue ?? "")
+			.appendTo($root);
 
-        this.$input = $("<input>")
-            .attr("id", "text")
-            .appendTo(this.$form);
+		const $buttons = $("<div>").addClass("prompt__buttons").appendTo($root);
+		$("<button>")
+			.attr({ type: "button", "data-prompt-action": "cancel" })
+			.text(opts.cancelLabel ?? "Cancel")
+			.appendTo($buttons);
+		$("<button>")
+			.attr({ type: "submit", "data-prompt-action": "confirm" })
+			.text(opts.confirmLabel ?? "Submit")
+			.appendTo($buttons);
 
-        $("<button>")
-            .attr("type", "submit")
-            .html("Submit")
-            .appendTo(this.$form);
-    }
+		return $root;
+	}
 
-    public getPromise(): Promise<string | number | string[]> {
-        return this.promise;
-    }
+	public static ask(message: string, opts?: PromptOptions): Promise<string | null> {
+		return new Prompt(message, opts).promise;
+	}
 }

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -240,9 +240,12 @@ export class TemplateBuilder {
 			const titleInput = this.titleInputEl;
 			const bodyTextarea = this.bodyTextareaEl;
 			if (!titleInput || !bodyTextarea) return;
-			// Reset DText tab to Write in case the previous template was left on Preview.
-			bodyTextarea.closest(".dtext-formatter")
-				?.querySelector<HTMLElement>('.dtext-formatter-tab[action="write"]')?.click();
+			// Reset DText tab to Write if the previous template was left on Preview.
+			// Skip the click if already on Write, since the state setter syncs heights from preview,
+			// which is hidden in Write mode and would collapse any user resize to 0.
+			const wrapper = bodyTextarea.closest<HTMLElement>(".dtext-formatter");
+			if (wrapper?.getAttribute("data-state") === "preview")
+				wrapper.querySelector<HTMLElement>('.dtext-formatter-tab[action="write"]')?.click();
 			titleInput.value = selected.title;
 			titleInput.readOnly = isPinned;
 			bodyTextarea.value = selected.body;

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -1,6 +1,8 @@
 import { JSONObject } from "../../components/Component";
 import XM from "../api/XM";
 import { IconName, makeIcon } from "../../utilities/UtilIcons";
+import { Confirm } from "./Confirm";
+import Modal from "./Modal";
 
 export interface TemplateData extends JSONObject {
 	title: string;
@@ -40,24 +42,10 @@ interface PageGlobals {
 	$?: typeof $;
 }
 
-/** Opens a jQuery UI dialog with the project's themed styling and Lucide close icon. */
-export function makeThemedDialog(content: HTMLElement, options: JQueryUI.DialogOptions): JQuery<HTMLElement> {
-	const $dialog = $(content).dialog({
-		appendTo: "#modal-container",
-		dialogClass: "template-builder-dialog",
-		modal: true,
-		resizable: false,
-		...options,
-	});
-	const closeBtn = ($dialog.dialog("widget") as JQuery<HTMLElement>).find(".ui-dialog-titlebar-close")[0];
-	if (closeBtn) closeBtn.replaceChildren(makeIcon("close"));
-	return $dialog;
-}
-
 export class TemplateBuilder {
 	private rowEl?: HTMLElement;
 	private modalEl?: HTMLElement;
-	private $modal?: JQuery<HTMLElement>;
+	private modal?: Modal;
 	private chipsAreaEl?: HTMLElement;
 	private formAreaEl?: HTMLElement;
 	private titleInputEl?: HTMLInputElement;
@@ -143,26 +131,27 @@ export class TemplateBuilder {
 		this.titleInputEl = undefined;
 		this.bodyTextareaEl = undefined;
 
-		this.$modal = this.themedDialog(root, {
+		this.modal = new Modal({
 			title: this.config.label,
+			content: $(root),
+			autoOpen: true,
 			width: 880,
 			height: "auto",
-			resizable: true,
-			close: () => this.disposeModal(),
 		});
+		this.modal.getElement().on("dialogclose", () => this.disposeModal());
 
 		this.refreshChips();
 		this.refreshForm();
 	}
 
 	private closeManager(): void {
-		if (this.$modal) this.$modal.dialog("close");
+		this.modal?.close();
 	}
 
 	private disposeModal(): void {
-		if (!this.$modal) return;
-		this.$modal.dialog("destroy");
-		this.$modal = undefined;
+		if (!this.modal) return;
+		this.modal.destroy();
+		this.modal = undefined;
 		this.modalEl = undefined;
 		this.chipsAreaEl = undefined;
 		this.formAreaEl = undefined;
@@ -455,7 +444,7 @@ export class TemplateBuilder {
 
 		const t = templates[this.selectedIndex];
 		if (!t) return;
-		const ok = await this.confirm(`Delete "${t.title || "(untitled)"}"?`, "Delete", { danger: true });
+		const ok = await Confirm.ask(`Delete "${t.title || "(untitled)"}"?`, { confirmLabel: "Delete", danger: true });
 		if (!ok) return;
 		const next = templates.filter((_, i) => i !== this.selectedIndex);
 		this.selectedIndex = -1;
@@ -466,7 +455,7 @@ export class TemplateBuilder {
 	}
 
 	private async reset(): Promise<void> {
-		const ok = await this.confirm("Reset all templates to defaults?", "Reset", { danger: true });
+		const ok = await Confirm.ask("Reset all templates to defaults?", { confirmLabel: "Reset", danger: true });
 		if (!ok) return;
 		this.config.setTemplates([...(this.config.defaults ?? [])]);
 		const pinned = this.config.pinnedChip;
@@ -577,7 +566,12 @@ export class TemplateBuilder {
 		document.body.appendChild(menu);
 		const rect = anchor.getBoundingClientRect();
 		menu.style.top = `${rect.bottom + window.scrollY + 4}px`;
-		menu.style.left = `${rect.left + window.scrollX - menu.offsetWidth + rect.width}px`;
+		// Right-align the menu's right edge with the anchor; clamp so the menu can't run off either edge of the viewport.
+		const margin = 4;
+		const idealLeft = rect.right + window.scrollX - menu.offsetWidth;
+		const minLeft = window.scrollX + margin;
+		const maxLeft = window.scrollX + window.innerWidth - menu.offsetWidth - margin;
+		menu.style.left = `${Math.max(minLeft, Math.min(idealLeft, maxLeft))}px`;
 
 		const onOutside = (e: MouseEvent) => {
 			if (!menu.contains(e.target as Node)) closeMenu();
@@ -594,52 +588,6 @@ export class TemplateBuilder {
 			document.addEventListener("mousedown", onOutside);
 			document.addEventListener("keydown", onEscape);
 		}, 0);
-	}
-
-	private confirm(message: string, confirmLabel = "OK", opts: { danger?: boolean } = {}): Promise<boolean> {
-		return new Promise((resolve) => {
-			const root = document.createElement("div");
-			root.className = "template-builder-confirm";
-
-			const msg = document.createElement("div");
-			msg.textContent = message;
-			root.appendChild(msg);
-
-			const buttons = document.createElement("div");
-			buttons.className = "template-builder-confirm__buttons";
-
-			let closed = false;
-			const cancelBtn = document.createElement("button");
-			cancelBtn.type = "button";
-			cancelBtn.textContent = "Cancel";
-			cancelBtn.addEventListener("click", () => done(false));
-
-			const okBtn = document.createElement("button");
-			okBtn.type = "button";
-			okBtn.textContent = confirmLabel;
-			if (opts.danger) okBtn.classList.add("template-builder-confirm__danger");
-			okBtn.addEventListener("click", () => done(true));
-
-			buttons.append(cancelBtn, okBtn);
-			root.appendChild(buttons);
-
-			const $dialog = this.themedDialog(root, {
-				title: "Confirm",
-				width: "auto",
-				close: () => done(false),
-			});
-
-			function done(value: boolean) {
-				if (closed) return;
-				closed = true;
-				$dialog.dialog("destroy");
-				resolve(value);
-			}
-		});
-	}
-
-	private themedDialog(root: HTMLElement, options: JQueryUI.DialogOptions): JQuery<HTMLElement> {
-		return makeThemedDialog(root, options);
 	}
 
 	private toast(message: string): void {

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -22,8 +22,8 @@ export interface TemplateBuilderConfig {
 	defaults?: TemplateData[];
 	/** Optional transform applied at insert time (e.g. greeting / variable expansion). */
 	transform?: (template: TemplateData) => string;
-	/** How clicking a chip integrates the template body into the target field. Defaults to "append". */
-	insertMode?: "replace" | "append";
+	/** How clicking a chip integrates the template body into the target field. Defaults to "insert". */
+	insertMode?: "replace" | "insert";
 	/** Extra entries appended to the manager's kebab menu (per-host actions). */
 	extraMenuItems?: Array<{ icon: IconName; label: string; onClick: () => void }>;
 	/** A non-deletable, non-draggable chip pinned next to the kebab. Edits a separate value (e.g. a greeting). */
@@ -101,7 +101,7 @@ export class TemplateBuilder {
 		const text = this.config.transform ? this.config.transform(template) : template.body;
 		if (!text) return;
 		const target = this.config.targetField;
-		const mode = this.config.insertMode ?? "append";
+		const mode = this.config.insertMode ?? "insert";
 		let start: number;
 		let end: number;
 		if (mode === "replace") {
@@ -109,10 +109,12 @@ export class TemplateBuilder {
 			start = 0;
 			end = text.length;
 		} else {
-			start = target.value.length;
-			target.value += text;
+			start = target.selectionStart;
+			target.value = `${target.value.substring(0, target.selectionStart)}${text}${target.value.substring(target.selectionEnd)}`;
 			end = start + text.length;
+			target.selectionStart = target.selectionEnd = end;
 		}
+		/** @todo Make this a setting you can toggle on desktop. */
 		// On touch (no-hover) devices, select the inserted range so it can be wiped with a single keystroke.
 		if (!matchMedia("(hover: hover)").matches)
 			target.setSelectionRange(start, end);

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -102,7 +102,6 @@ export class TemplateBuilder {
 		if (!text) return;
 		const target = this.config.targetField;
 		const mode = this.config.insertMode ?? "append";
-		// Track the inserted range so we can select it after.
 		let start: number;
 		let end: number;
 		if (mode === "replace") {
@@ -110,16 +109,13 @@ export class TemplateBuilder {
 			start = 0;
 			end = text.length;
 		} else {
-			// If there's a selection, replace it. Otherwise append at end.
-			const selStart = target.selectionStart;
-			const selEnd = target.selectionEnd;
-			const hasSelection = selStart !== null && selEnd !== null && selStart !== selEnd;
-			start = hasSelection ? selStart : target.value.length;
-			const tail = hasSelection ? target.value.substring(selEnd) : "";
-			target.value = target.value.substring(0, start) + text + tail;
+			start = target.value.length;
+			target.value += text;
 			end = start + text.length;
 		}
-		target.setSelectionRange(start, end);
+		// On touch (no-hover) devices, select the inserted range so it can be wiped with a single keystroke.
+		if (!matchMedia("(hover: hover)").matches)
+			target.setSelectionRange(start, end);
 		target.dispatchEvent(new Event("input", { bubbles: true }));
 		target.focus();
 	}

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -22,6 +22,8 @@ export interface TemplateBuilderConfig {
 	defaults?: TemplateData[];
 	/** Optional transform applied at insert time (e.g. greeting / variable expansion). */
 	transform?: (template: TemplateData) => string;
+	/** How clicking a chip integrates the template body into the target field. Defaults to "append". */
+	insertMode?: "replace" | "append";
 	/** Extra entries appended to the manager's kebab menu (per-host actions). */
 	extraMenuItems?: Array<{ icon: IconName; label: string; onClick: () => void }>;
 	/** A non-deletable, non-draggable chip pinned next to the kebab. Edits a separate value (e.g. a greeting). */
@@ -99,7 +101,25 @@ export class TemplateBuilder {
 		const text = this.config.transform ? this.config.transform(template) : template.body;
 		if (!text) return;
 		const target = this.config.targetField;
-		target.value = text;
+		const mode = this.config.insertMode ?? "append";
+		// Track the inserted range so we can select it after.
+		let start: number;
+		let end: number;
+		if (mode === "replace") {
+			target.value = text;
+			start = 0;
+			end = text.length;
+		} else {
+			// If there's a selection, replace it. Otherwise append at end.
+			const selStart = target.selectionStart;
+			const selEnd = target.selectionEnd;
+			const hasSelection = selStart !== null && selEnd !== null && selStart !== selEnd;
+			start = hasSelection ? selStart : target.value.length;
+			const tail = hasSelection ? target.value.substring(selEnd) : "";
+			target.value = target.value.substring(0, start) + text + tail;
+			end = start + text.length;
+		}
+		target.setSelectionRange(start, end);
 		target.dispatchEvent(new Event("input", { bubbles: true }));
 		target.focus();
 	}

--- a/src/js/models/structure/TemplateBuilder.ts
+++ b/src/js/models/structure/TemplateBuilder.ts
@@ -1,5 +1,5 @@
 import { JSONObject } from "../../components/Component";
-import XM from "../api/XM";
+import Danbooru from "../api/Danbooru";
 import { IconName, makeIcon } from "../../utilities/UtilIcons";
 import { Confirm } from "./Confirm";
 import Modal from "./Modal";
@@ -36,11 +36,6 @@ export interface TemplateBuilderConfig {
 
 /** Sentinel value for `selectedIndex` indicating the pinned chip is selected. */
 const PINNED_INDEX = -2;
-
-interface PageGlobals {
-	E621?: { DTextFormatter?: { buildFromTextarea($textarea: JQuery<HTMLTextAreaElement>): unknown } };
-	$?: typeof $;
-}
 
 export class TemplateBuilder {
 	private rowEl?: HTMLElement;
@@ -237,8 +232,7 @@ export class TemplateBuilder {
 			bodyTextarea.value = selected.body;
 			if (this.deleteBtnEl) this.deleteBtnEl.style.visibility = isPinned ? "hidden" : "";
 			// Refresh DText preview by triggering its namespaced jQuery event.
-			const pageWindow = XM.Window as unknown as PageGlobals;
-			pageWindow.$?.(bodyTextarea).trigger("input.dtext_formatter");
+			Danbooru.jQuery?.(bodyTextarea).trigger("input.dtext_formatter");
 		} else {
 			this.titleInputEl = undefined;
 			this.bodyTextareaEl = undefined;
@@ -357,11 +351,8 @@ export class TemplateBuilder {
 	}
 
 	private attachDText(textarea: HTMLTextAreaElement): void {
-		// DTextFormatter lives on the page window, not the userscript sandbox.
-		// Must use the page's jQuery instance too, otherwise it doesn't recognize the element.
-		const pageWindow = XM.Window as unknown as PageGlobals;
-		const formatter = pageWindow.E621?.DTextFormatter;
-		const page$ = pageWindow.$;
+		const formatter = Danbooru.DTextFormatter;
+		const page$ = Danbooru.jQuery;
 		if (!formatter || !page$) return;
 		// Marker class makes the formatter dispatch a native `input` event after its buttons
 		// modify the textarea. Without it, only a namespaced jQuery event fires and our listener misses it.
@@ -478,7 +469,7 @@ export class TemplateBuilder {
 		a.click();
 		a.remove();
 		URL.revokeObjectURL(url);
-		this.toast("Saved templates.json");
+		Danbooru.notice("Saved templates.json");
 	}
 
 	private importFromFile(): void {
@@ -498,11 +489,11 @@ export class TemplateBuilder {
 		try {
 			parsed = JSON.parse(text);
 		} catch {
-			this.toast("Invalid JSON file");
+			Danbooru.error("Invalid JSON file");
 			return;
 		}
 		if (!Array.isArray(parsed)) {
-			this.toast("Expected an array of templates");
+			Danbooru.error("Expected an array of templates");
 			return;
 		}
 
@@ -521,7 +512,7 @@ export class TemplateBuilder {
 		this.renderRow();
 		this.refreshChips();
 		this.refreshForm();
-		this.toast(`Imported ${additions.length} template${additions.length === 1 ? "" : "s"}`);
+		Danbooru.notice(`Imported ${additions.length} template${additions.length === 1 ? "" : "s"}`);
 	}
 
 	// #endregion
@@ -588,18 +579,6 @@ export class TemplateBuilder {
 			document.addEventListener("mousedown", onOutside);
 			document.addEventListener("keydown", onEscape);
 		}, 0);
-	}
-
-	private toast(message: string): void {
-		const el = document.createElement("div");
-		el.className = "template-builder-toast";
-		el.textContent = message;
-		document.body.appendChild(el);
-		requestAnimationFrame(() => el.classList.add("template-builder-toast--show"));
-		setTimeout(() => {
-			el.classList.remove("template-builder-toast--show");
-			setTimeout(() => el.remove(), 300);
-		}, 1800);
 	}
 
 	// #endregion


### PR DESCRIPTION
- Replaces the custom modal in the template builder with the standard modal 
- Fixes dependency on re621 main
- Adds some styling to the standard modal
- Makes standard modal responsive on mobile
- Fixes dtext in modal not staying resized
- Throws out old code in th danbooru wrapper that isnt actually in the e621ng global JS anymore
- Adds `%body%` variable to the Ticket greeting template, allowing to write a signature as well
- Brings back Append mode for Forum and Dmail
- Brings back automatic selection on mobile
- Refactors confirm and prompt dialog